### PR TITLE
Add req.files to event

### DIFF
--- a/template/node12-restify/index.js
+++ b/template/node12-restify/index.js
@@ -14,6 +14,7 @@ class FunctionEvent {
         this.method = req.method;
         this.query = req.query;
         this.path = req.path;
+        this.files = req.files;
     }
 }
 


### PR DESCRIPTION
Hi, thanks for the template, avoided me some extra work :)  

I needed to send attachments, and the `req.files` wasn't forwarded in the event, adding it did the trick and now it can be accessed through `event.files` (`null` if empty, `object` if there are uploads).  

